### PR TITLE
In IE11, clicking on a slider triggered an event which had no pageX/Y…

### DIFF
--- a/jqColorPicker.js
+++ b/jqColorPicker.js
@@ -57,8 +57,10 @@
 	}
 
 	function resolveEventType(event) {
-		return event.originalEvent.touches ?
+		event = event.originalEvent.touches ?
 			event.originalEvent.touches[0] : event;
+
+		return event.originalEvent ? event.originalEvent : event;
 	}
 
 	function findElement($elm) {


### PR DESCRIPTION
When clicking on a slider on IE11, most of the values were calculated as NaN. After debugging, I saw that the methods xy_slider, z_slider and alpha call the method resolveEventType to get the event and try to get the pageX and pageY from it.
In my case those were undefined and thus created some NaN values.
The event contained an "originalEvent" attribute containing those values.

This may also fix the issue #24, The problem described look like mine.

Thanks.
