### PR TITLE
Need to have a good default z-index

### DIFF
--- a/development/colorPicker.css
+++ b/development/colorPicker.css
@@ -1,5 +1,6 @@
 .cp-color-picker {
 	position: absolute;
+	z-index: 9999;
 	padding: 6px 6px 0;
 	background-color: #444;
 	color: #bbb;


### PR DESCRIPTION
I don't see any reason for anything to be above the color-picker when activated.  9999 seems safe enough to me.
